### PR TITLE
Replace fmt logging with standard streams

### DIFF
--- a/bitsliced_verushash_miner.cu
+++ b/bitsliced_verushash_miner.cu
@@ -18,14 +18,10 @@
 #include <cstring>
 #include <algorithm>
 #include <stdexcept>
-
-#include <fmt/core.h>
-#include <fmt/color.h>
-
-=======
 #include <fstream>
 #include <cctype>
-=======
+#include <cstdio>
+#include <cstdarg>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -76,52 +72,44 @@ std::atomic<uint32_t> g_shares_rejected{0};
 
 std::atomic<bool> g_summary_active{false};
 
-enum class LogType { Status, Error, Success, Warn };
-
-template <typename... Args>
-void log_message(LogType type, fmt::format_string<Args...> fmt_str, Args&&... args) {
-    if (g_summary_active.exchange(false)) fmt::print("\n");
-    fmt::text_style style;
-    switch (type) {
-        case LogType::Status:
-            style = fmt::fg(fmt::color::cyan);
-            break;
-        case LogType::Error:
-            style = fmt::fg(fmt::color::red) | fmt::emphasis::bold;
-            break;
-        case LogType::Success:
-            style = fmt::fg(fmt::color::green);
-            break;
-        case LogType::Warn:
-            style = fmt::fg(fmt::color::yellow);
-            break;
-    }
-    fmt::print(style, fmt_str, std::forward<Args>(args)...);
-    fmt::print("\n");
+void log_status(const char* fmt, ...) {
+    if (g_summary_active.exchange(false)) std::printf("\n");
+    va_list args;
+    va_start(args, fmt);
+    std::vprintf(fmt, args);
+    va_end(args);
+    std::printf("\n");
 }
 
-template <typename... Args>
-void log_status(fmt::format_string<Args...> fmt_str, Args&&... args) {
-    log_message(LogType::Status, fmt_str, std::forward<Args>(args)...);
+void log_error(const char* fmt, ...) {
+    if (g_summary_active.exchange(false)) std::fprintf(stderr, "\n");
+    va_list args;
+    va_start(args, fmt);
+    std::vfprintf(stderr, fmt, args);
+    va_end(args);
+    std::fprintf(stderr, "\n");
 }
 
-template <typename... Args>
-void log_error(fmt::format_string<Args...> fmt_str, Args&&... args) {
-    log_message(LogType::Error, fmt_str, std::forward<Args>(args)...);
+void log_success(const char* fmt, ...) {
+    if (g_summary_active.exchange(false)) std::printf("\n");
+    va_list args;
+    va_start(args, fmt);
+    std::vprintf(fmt, args);
+    va_end(args);
+    std::printf("\n");
 }
 
-template <typename... Args>
-void log_success(fmt::format_string<Args...> fmt_str, Args&&... args) {
-    log_message(LogType::Success, fmt_str, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-void log_warn(fmt::format_string<Args...> fmt_str, Args&&... args) {
-    log_message(LogType::Warn, fmt_str, std::forward<Args>(args)...);
+void log_warn(const char* fmt, ...) {
+    if (g_summary_active.exchange(false)) std::printf("\n");
+    va_list args;
+    va_start(args, fmt);
+    std::vprintf(fmt, args);
+    va_end(args);
+    std::printf("\n");
 }
 
 void print_summary(double hashrate) {
-    fmt::print("\rHashrate: {:.2f} MH/s | Shares F:{} A:{} R:{}",
+    std::printf("\rHashrate: %.2f MH/s | Shares F:%u A:%u R:%u",
                hashrate,
                g_shares_found.load(),
                g_shares_accepted.load(),
@@ -135,7 +123,7 @@ void print_summary(double hashrate) {
     do { \
         cudaError_t error = call; \
         if (error != cudaSuccess) { \
-            log_error("CUDA Error at {}:{} - {}", __FILE__, __LINE__, cudaGetErrorString(error)); \
+            log_error("CUDA Error at %s:%d - %s", __FILE__, __LINE__, cudaGetErrorString(error)); \
             exit(1); \
         } \
     } while(0)
@@ -772,7 +760,7 @@ public:
 
         connected = true;
 
-        log_status("CONNECTED to {}:{}", POOL_HOST, POOL_PORT);
+        log_status("CONNECTED to %s:%d", POOL_HOST, POOL_PORT);
 =======
         std::cout << "CONNECTED to " << pool_host << ":" << pool_port << std::endl;
 
@@ -787,7 +775,7 @@ public:
         }
         
         std::string response = receive_line();
-        log_status("Subscribe response: {}", response);
+        log_status("Subscribe response: %s", response.c_str());
         
         // Parse subscribe result: [[subscriptions], extranonce1, extranonce2_size]
         if (response.find("\"result\"") != std::string::npos) {
@@ -803,7 +791,7 @@ public:
                 q2 = arr.find('"', q1 + 1);
                 if (q1 != std::string::npos && q2 != std::string::npos) {
                     extranonce1 = arr.substr(q1 + 1, q2 - q1 - 1);
-                    log_status("Extracted extranonce1: {}", extranonce1);
+                    log_status("Extracted extranonce1: %s", extranonce1.c_str());
                 }
                 
                 // Last integer is extranonce2_size
@@ -811,7 +799,7 @@ public:
                 if (lastComma != std::string::npos) {
                     extranonce2_size = atoi(arr.c_str() + lastComma + 1);
                     if (extranonce2_size <= 0 || extranonce2_size > 16) extranonce2_size = 4;
-                    log_status("Extracted extranonce2_size: {}", extranonce2_size);
+                    log_status("Extracted extranonce2_size: %d", extranonce2_size);
                 }
             }
         }
@@ -828,7 +816,7 @@ public:
         }
         
         response = receive_line();
-        log_status("Auth response: {}", response);
+        log_status("Auth response: %s", response.c_str());
         
         // Process the auth response - might be a mining.set_target message
         if (response.find("mining.set_target") != std::string::npos) {
@@ -837,7 +825,7 @@ public:
             size_t bracket_end = response.find("\"]");
             if (bracket_start != std::string::npos && bracket_end != std::string::npos && bracket_end > bracket_start) {
                 std::string targ_hex = response.substr(bracket_start + 2, bracket_end - bracket_start - 2);
-                log_status("Found target hex in auth: {}", targ_hex);
+                log_status("Found target hex in auth: %s", targ_hex.c_str());
                 // strict decode: 64 hex chars -> 32 bytes LE
                 if (targ_hex.size() >= 64) {
                     for (int i=0;i<32;i++) {
@@ -848,7 +836,7 @@ public:
                         }
                     }
                     have_share_target = true;
-                    log_status("Set target from pool: {}...", targ_hex.substr(0, 16));
+                    log_status("Set target from pool: %s...", targ_hex.substr(0, 16).c_str());
                 }
             }
         }
@@ -863,14 +851,14 @@ public:
         std::string message = receive_line();
         if (message.empty()) return false;
         
-        log_status("Received message: {}", message);
+        log_status("Received message: %s", message.c_str());
         
         if (message.find("mining.set_difficulty") != std::string::npos) {
             size_t lb = message.find('['), rb = message.find(']');
             if (lb != std::string::npos && rb != std::string::npos) {
                 current_difficulty = atof(message.substr(lb+1, rb-lb-1).c_str());
                 have_share_target = false; // recompute from diff next time
-                log_status("Set difficulty: {}", current_difficulty);
+                log_status("Set difficulty: %.2f", current_difficulty);
             }
             return false;
         }
@@ -890,8 +878,8 @@ public:
                         }
                     }
                     have_share_target = true;
-                    log_status("Set target from pool: {}...", targ_hex.substr(0, 16));
-                    log_status("Parsed target (LE): {:#x}", *(uint32_t*)&share_target_le[28]);
+                    log_status("Set target from pool: %s...", targ_hex.substr(0, 16).c_str());
+                    log_status("Parsed target (LE): %#x", *(uint32_t*)&share_target_le[28]);
                 }
             }
             return false;
@@ -993,23 +981,23 @@ public:
                     extranonce2_counter = 0;         // (optional) restart per-job counter
                     clean_jobs_flag = clean_jobs;
                     
-                    log_status("Job ID: {}", job_id);
-                    log_status("Version: {}", version);
-                    log_status("Prevhash: {}...", prevhash.substr(0, 20));
-                    log_status("Coinb1 length: {}", coinb1.length());
-                    log_status("Coinb2 length: {}", coinb2.length());
-                    log_status("Merkle branch entries: {}", merkle_branch.size());
-                    log_status("Ntime: {}", ntime);
-                    log_status("Nbits: {}", nbits);
-                    log_status("Clean jobs: {}", clean_jobs_flag ? "true" : "false");
+                    log_status("Job ID: %s", job_id.c_str());
+                    log_status("Version: %s", version.c_str());
+                    log_status("Prevhash: %s...", prevhash.substr(0, 20).c_str());
+                    log_status("Coinb1 length: %zu", coinb1.length());
+                    log_status("Coinb2 length: %zu", coinb2.length());
+                    log_status("Merkle branch entries: %zu", merkle_branch.size());
+                    log_status("Ntime: %s", ntime.c_str());
+                    log_status("Nbits: %s", nbits.c_str());
+                    log_status("Clean jobs: %s", clean_jobs_flag ? "true" : "false");
                 } else {
-                    log_error("Failed to parse all required fields (got {}/7)", string_fields.size());
+                    log_error("Failed to parse all required fields (got %zu/7)", string_fields.size());
                 }
             }
             
             // Create one extranonce2 for this job and build the header with it
             current_extranonce2 = make_extranonce2(extranonce2_counter++, extranonce2_size);
-            log_status("Generated extranonce2: {}", current_extranonce2);
+            log_status("Generated extranonce2: %s", current_extranonce2.c_str());
             
             build_verus_header_from_job(current_extranonce2, header);
             return true;
@@ -1114,7 +1102,7 @@ main
     stratum.get_share_target_le(target_le_host);
 
     
-    log_status("Current difficulty: {}", stratum.get_current_difficulty());
+    log_status("Current difficulty: %.2f", stratum.get_current_difficulty());
 =======
 
     std::cout << "Current difficulty: " << stratum.get_current_difficulty() << std::endl;
@@ -1214,7 +1202,7 @@ main
 
         if (h_found_count > 0) {
 
-            log_warn("FOUND {} potential shares!", h_found_count);
+            log_warn("FOUND %u potential shares!", h_found_count);
 
             uint32_t to_copy = std::min(h_found_count, 8u);
             CUDA_CHECK(cudaMemcpy(h_found_nonces, d_found_nonces, to_copy * sizeof(uint32_t), cudaMemcpyDeviceToHost));
@@ -1238,10 +1226,12 @@ main
                 std::cout << " Hash: ";
 
                 for (int j = 0; j < 32; j++) {
-                    hash_hex += fmt::format("{:02x}", h_found_hashes[i * 32 + j]);
+                    char buf[3];
+                    std::snprintf(buf, sizeof(buf), "%02x", h_found_hashes[i * 32 + j]);
+                    hash_hex += buf;
                 }
 
-                log_status("Share found! Nonce: {:#x} Hash: {}", found_nonce, hash_hex);
+                log_status("Share found! Nonce: %#x Hash: %s", found_nonce, hash_hex.c_str());
 
                 // Check if we still have the same job before submitting
 
@@ -1311,9 +1301,9 @@ int main(int argc, char** argv) {
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, 0);
     
-    log_status("Mining Device: {}", prop.name);
-    log_status("Architecture: sm_{}{}", prop.major, prop.minor);
-    fmt::print("\n");
+    log_status("Mining Device: %s", prop.name);
+    log_status("Architecture: sm_%d%d", prop.major, prop.minor);
+    std::cout << std::endl;
     
     MinerConfig cfg = parse_config(argc, argv);
 
@@ -1341,12 +1331,12 @@ int main(int argc, char** argv) {
     const int BLOCKS_PER_GRID = prop.multiProcessorCount * 4;
     
     log_status("Bitsliced Configuration:");
-    log_status("- Hashes per warp: {}", BITSLICE_WIDTH);
-    log_status("- Warps per block: {}", WARPS_PER_BLOCK);
-    log_status("- Blocks: {}", BLOCKS_PER_GRID);
-    log_status("- Total parallel hashes: {}", BLOCKS_PER_GRID * WARPS_PER_BLOCK * BITSLICE_WIDTH);
-    log_status("- Batch size: {} nonces", BATCH_SIZE);
-    fmt::print("\n");
+    log_status("- Hashes per warp: %d", BITSLICE_WIDTH);
+    log_status("- Warps per block: %d", WARPS_PER_BLOCK);
+    log_status("- Blocks: %d", BLOCKS_PER_GRID);
+    log_status("- Total parallel hashes: %d", BLOCKS_PER_GRID * WARPS_PER_BLOCK * BITSLICE_WIDTH);
+    log_status("- Batch size: %u nonces", BATCH_SIZE);
+    std::cout << std::endl;
     
     // Start bitsliced mining
     log_status("Starting bitsliced VerusHash mining...");
@@ -1354,7 +1344,7 @@ int main(int argc, char** argv) {
     try {
         run_bitsliced_mining(cfg);
     } catch (const std::exception& e) {
-        log_error("Mining error: {}", e.what());
+        log_error("Mining error: %s", e.what());
     }
 
     log_status("Mining stopped.");

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ fi
 
 # Build with GCC
 nvcc bitsliced_verushash_miner.cu -o miner \
-     -std=c++17 -O3 --ptxas-options=-v -arch=sm_89 -DCUDA_ARCH=89 -lfmt
+     -std=c++17 -O3 --ptxas-options=-v -arch=sm_89 -DCUDA_ARCH=89
 
 if [ $? -eq 0 ]; then
     echo "Build successful! Run ./miner to start mining."


### PR DESCRIPTION
## Summary
- Drop fmt includes and dependency
- Rework logging helpers to use printf/stdout
- Convert log messages to printf-style formatting

## Testing
- `sed 's/\r$//' build.sh | bash` *(fails: nvcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c60d15308832b905f0f5d31efd781